### PR TITLE
Install per-user w/ admin required instead of per-machine

### DIFF
--- a/TraXile_Setup.aip
+++ b/TraXile_Setup.aip
@@ -3,7 +3,7 @@
   <COMPONENT cid="caphyon.advinst.msicomp.MsiPropsComponent">
     <ROW Property="AI_APP_FILE" Value="[#TraXile.exe]"/>
     <ROW Property="AI_BITMAP_DISPLAY_MODE" Value="0"/>
-    <ROW Property="ALLUSERS" Value="1" MultiBuildValue="DefaultBuild:"/>
+    <ROW Property="ALLUSERS" Value="1" MultiBuildValue="DefaultBuild:3"/>
     <ROW Property="ARPCOMMENTS" Value="This installer database contains the logic and data required to install TraXile." ValueLocId="*"/>
     <ROW Property="ARPCONTACT" Value="dermow@posteo.de"/>
     <ROW Property="ARPHELPLINK" Value="https://github.com/dermow/TraXile"/>


### PR DESCRIPTION
* Installs to AppData instead of Program Files
* After a few versions/updates all "program files" installs will have been
  cleaned up and it can migrate to "per user only" (no admin/UAC required)