### PR TITLE
Add support for "Reflecting Mist" & "The Nameless Seer" encounters

### DIFF
--- a/TraXile/TrX_CoreLogic.cs
+++ b/TraXile/TrX_CoreLogic.cs
@@ -431,6 +431,8 @@ namespace TraXile
                 new TrX_ActivityTag("zana") { BackColor = Color.Blue, ForeColor = Color.White, ShowInListView = true },
                 new TrX_ActivityTag("niko") { BackColor = Color.OrangeRed, ForeColor = Color.Black, ShowInListView = true },
                 new TrX_ActivityTag("zana-map") { BackColor = Color.Blue, ForeColor = Color.Black, ShowInListView = true },
+                new TrX_ActivityTag("seer") { BackColor = Color.Red, ForeColor = Color.Black, ShowInListView = true },
+                new TrX_ActivityTag("mist") { BackColor = Color.Red, ForeColor = Color.Black, ShowInListView = true },
                 new TrX_ActivityTag("expedition") { BackColor = Color.Turquoise, ForeColor = Color.Black, ShowInListView = true },
                 new TrX_ActivityTag("rog") { BackColor = Color.Turquoise, ForeColor = Color.Black },
                 new TrX_ActivityTag("gwennen") { BackColor = Color.Turquoise, ForeColor = Color.Black },
@@ -598,6 +600,8 @@ namespace TraXile
                 { "LabsFinished", 0 },
                 { "LabsStarted", 0 },
                 { "LevelUps", 0 },
+                { "NamelessSeerEncounters", 0 },
+                { "ReflectingMistEncounters", 0 },
                 { "TotalMapsDone", 0 },
                 { "TotalHeistsDone", 0 },
                 { "SanctumKilledLycia1", 0 },
@@ -625,6 +629,8 @@ namespace TraXile
                 { "TrialMasterVictory", "Ultimatum: cleared all rounds" },
                 { "TrialMasterSuccess", "Ultimatum: did not fail" },
                 { "LevelUps", "Level Ups" },
+                { "NamelessSeerEncounters", "Encounters with The Nameless Seer" },
+                { "ReflectingMistEncounters", "Encounters with The Reflecting Mist" },
                 { "SimulacrumStarted", "Simulacrum started" },
                 { "SimulacrumCleared", "Simulacrum 100% done" },
                 { "LabsFinished", "Finished labs" },
@@ -2381,6 +2387,38 @@ namespace TraXile
                             else
                             {
                                 _currentActivity.AddTag("delirium");
+                            }
+                        }
+                        break;
+                    case EVENT_TYPES.NAMELESSSEER_ENCOUNTER:
+
+                        IncrementStat("NamelessSeerEncounters", ev.EventTime, 1);
+
+                        if (CheckIfAreaIsMap(_currentArea) && _currentActivity != null)
+                        {
+                            if (_isMapZana && _currentActivity.SideArea_ZanaMap != null)
+                            {
+                                _currentActivity.SideArea_ZanaMap.AddTag("seer");
+                            }
+                            else
+                            {
+                                _currentActivity.AddTag("seer");
+                            }
+                        }
+                        break;
+                    case EVENT_TYPES.REFLECTINGMIST_ENCOUNTER:
+
+                        IncrementStat("ReflectingMistEncounters", ev.EventTime, 1);
+
+                        if (CheckIfAreaIsMap(_currentArea) && _currentActivity != null)
+                        {
+                            if (_isMapZana && _currentActivity.SideArea_ZanaMap != null)
+                            {
+                                _currentActivity.SideArea_ZanaMap.AddTag("mist");
+                            }
+                            else
+                            {
+                                _currentActivity.AddTag("mist");
                             }
                         }
                         break;

--- a/TraXile/TrX_EventMapping.cs
+++ b/TraXile/TrX_EventMapping.cs
@@ -24,6 +24,8 @@ namespace TraXile
         EINHAR_ENCOUNTER,
         ZANA_ENCOUNTER,
         SYNDICATE_ENCOUNTER,
+        NAMELESSSEER_ENCOUNTER,
+        REFLECTINGMIST_ENCOUNTER,
         LEVELUP,
         SIMULACRUM_FULLCLEAR,
         CHAT_CMD_RECEIVED,
@@ -322,6 +324,8 @@ namespace TraXile
 
                 // Encounters
                 {"Strange Voice: ", EVENT_TYPES.DELIRIUM_ENCOUNTER },
+                {"The Nameless Seer has appeared nearby.", EVENT_TYPES.NAMELESSSEER_ENCOUNTER },
+                {"A Reflecting Mist has manifested nearby.", EVENT_TYPES.REFLECTINGMIST_ENCOUNTER },
                 {"Sister Cassia: ", EVENT_TYPES.BLIGHT_ENCOUNTER },
                 {"Niko, Master of the Depths: ", EVENT_TYPES.NIKO_ENCOUNTER },
                 {"Alva, Master Explorer: ", EVENT_TYPES.INCURSION_ENCOUNTER },

--- a/TraXile/UI/Main.Designer.cs
+++ b/TraXile/UI/Main.Designer.cs
@@ -2577,7 +2577,7 @@ namespace TraXile
             // columnHeader23
             // 
             this.columnHeader23.Text = "Stat";
-            this.columnHeader23.Width = 200;
+            this.columnHeader23.Width = 275;
             // 
             // columnHeader24
             // 


### PR DESCRIPTION
Draft PR for Issue #149

I've added this to the 2.1.5 branch rather than master. Hope this is ok.

Not sure if you have a preference for the tag colours?

**Summary**

1. Adds an incremental tracker for "The Nameless Seer" encounters
2. Adds an incremental tracker for "Reflecting Mist" encounters
3. Adds an event type for "The Nameless Seer" encounters
4. Adds an event type for "Reflecting Mist" encounters
5. Exposes "seer" and "mist" tags in the UI

Tested locally and seems to report the correct data from my log file (~650Mb from 4+ years):

Tracking Screen
![image](https://github.com/user-attachments/assets/dcd9141c-d9a8-4bd2-8c8b-f39d45b1517a)

Statistics->General Stats Screen
![image](https://github.com/user-attachments/assets/39a7bd0e-abb2-48b9-b342-a5a983d1919d)
